### PR TITLE
🔒 Add explicit permissions to CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
This PR adds explicit permissions to the CI job to resolve a CodeQL warning.